### PR TITLE
include asm/uaccess.h for copy_to_user

### DIFF
--- a/virtual_touchscreen.c
+++ b/virtual_touchscreen.c
@@ -5,6 +5,7 @@
 #include <linux/interrupt.h>
 #include <asm/io.h>
 #include <asm/delay.h>
+#include <asm/uaccess.h>
 
 #define MODNAME "virtual_touchscreen"
 


### PR DESCRIPTION
include asm/uaccess.h to prevent warning for copy_to_user:
`/drivers/virtual_touchscreen/virtual_touchscreen.c: In function 'device_read':
/drivers/virtual_touchscreen/virtual_touchscreen.c:126:5: error: implicit declaration of function 'copy_to_user' [-Werror=implicit-function-declaration]
     if (copy_to_user(buffer, message+off, length) != 0) {
`